### PR TITLE
change long snake (__) to dash (-). needed for post-xfer exec and pre-xf...

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Opscode, Inc.'
 maintainer_email  'cookbooks@opscode.com'
 license           'Apache 2.0'
 description       'Installs rsync'
-version           '0.8.5'
+version           '0.8.6'
 
 recipe 'rsync::default', 'Installs rsync, Provides LWRP rsync_serve for serving paths via rsyncd'
 recipe 'rsync::server', 'Installs rsync and starts a service to serve a directory'

--- a/providers/serve.rb
+++ b/providers/serve.rb
@@ -85,6 +85,8 @@ protected
       uid
       use_chroot
       write_only
+      pre__xfer_exec
+      post__xfer_exec
     )
   end
 
@@ -97,13 +99,14 @@ protected
     end
   end
 
-  # Expand "snake_case_things" to "snake case things".
+  # Expand "snake_case_things" to "snake case things" and
+  # "snake__case_things" to "snake-case things"
   #
   # @param [String] string
   #
   # @return [String]
   def snake_to_space(string)
-    string.to_s.gsub(/_/, ' ')
+    string.to_s.gsub(/__/, '-').gsub(/_/, ' ')
   end
 
   # The list of rsync modules defined in the resource collection.

--- a/resources/serve.rb
+++ b/resources/serve.rb
@@ -41,3 +41,6 @@ attribute :timeout, :kind_of => Fixnum, :default => 600
 attribute :dont_compress, :kind_of  =>  String
 attribute :lock_file, :kind_of => String
 attribute :refuse_options, :kind_of => String
+# the rsyncd.conf has two options with dashes, we can not use dashes here -> let's use double_..
+attribute :pre__xfer_exec, :kind_of => String
+attribute :post__xfer_exec, :kind_of => String


### PR DESCRIPTION
Hi,

I was missing the possibility to add post-xfer and pre-xfer exec to the rsyncd.conf. As a workaround I've added a feature to change "__" to "-" in resource attributes.

I'm not really happy with this syntax, but it was an easy fix.. :) If there are better options, please let me know.

Cheers
Dennis