### PR TITLE
add \'incoming chmod\' and \'outgoing chmod\' option

### DIFF
--- a/providers/serve.rb
+++ b/providers/serve.rb
@@ -85,6 +85,8 @@ protected
       uid
       use_chroot
       write_only
+      incoming_chmod
+      outgoing_chmod
     )
   end
 

--- a/resources/serve.rb
+++ b/resources/serve.rb
@@ -41,3 +41,5 @@ attribute :timeout, :kind_of => Fixnum, :default => 600
 attribute :dont_compress, :kind_of  =>  String
 attribute :lock_file, :kind_of => String
 attribute :refuse_options, :kind_of => String
+attribute :incoming_chmod, :kind_of => String
+attribute :outgoing_chmod, :kind_of => String


### PR DESCRIPTION
I am trying to use rsync cookbook with openstack swift and it required the "incoming chmod" and "outgoing chmod" option in the rsyncd module.