### PR TITLE
Move method calls outside of template definition

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        'Chef Software, Inc.'
 maintainer_email  'cookbooks@chef.io'
 license           'Apache 2.0'
 description       'Installs rsync'
-version           '0.8.6'
+version           '0.8.7'
 
 recipe 'rsync::default', 'Installs rsync, Provides LWRP rsync_serve for serving paths via rsyncd'
 recipe 'rsync::server', 'Installs rsync and starts a service to serve a directory'

--- a/providers/serve.rb
+++ b/providers/serve.rb
@@ -25,11 +25,14 @@ action :remove do
 end
 
 protected
+
   #
   # Walk collection for :add rsync_serve resources
   # Build and write the config template
   #
   def write_conf
+    globals = global_modules
+    modules = rsync_modules
     t = template(new_resource.config_path) do
       source   'rsyncd.conf.erb'
       cookbook 'rsync'
@@ -37,8 +40,8 @@ protected
       group    'root'
       mode     '0640'
       variables(
-        :globals => global_modules,
-        :modules => rsync_modules
+        :globals => globals,
+        :modules => modules
       )
       notifies :restart, "service[#{node['rsyncd']['service']}]", :delayed
     end


### PR DESCRIPTION
I got the error shown below when using the `rsync_serve` resource with Chef client 12.1.1. This pull request fixes the issue for me.

Regards,

Peter

```
  * rsync_serve[repo] action add
    
    ================================================================================
    Error executing action `add` on resource 'rsync_serve[repo]'
    ================================================================================
    
    NoMethodError
    -------------
    undefined method `global_modules' for Chef::Resource::Template
    
    Cookbook Trace:
    ---------------
    /var/chef/cache/cookbooks/rsync/providers/serve.rb:40:in `block in write_conf'
    /var/chef/cache/cookbooks/rsync/providers/serve.rb:33:in `write_conf'
    /var/chef/cache/cookbooks/rsync/providers/serve.rb:20:in `block in class_from_file'
    
    Resource Declaration:
    ---------------------
    # In /var/chef/cache/cookbooks/repo/recipes/default.rb
    
     17: rsync_serve 'repo' do
     18: 	path '/repo'
     19: 	uid 'nobody'
     20: 	gid 'nobody'
     21: 	read_only true
     22: end
     23: 
    
    Compiled Resource:
    ------------------
    # Declared in /var/chef/cache/cookbooks/repo/recipes/default.rb:17:in `from_file'
    
    rsync_serve("repo") do
      action :add
      retries 0
      retry_delay 2
      default_guard_interpreter :default
      declared_type :rsync_serve
      cookbook_name "repo"
      recipe_name "default"
      path "/repo"
      uid "nobody"
      gid "nobody"
      read_only true
      config_path "/etc/rsyncd.conf"
    end
```